### PR TITLE
Add UBDCC to version check script

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,8 +86,8 @@ Isolated Margin, Futures, US and TR -- all with testnet support.
 
 ### [UNICORN Binance Local Depth Cache](https://github.com/oliver-zehentleitner/unicorn-binance-local-depth-cache) (UBLDC)
 Synchronized local order books with real-time WebSocket updates and automatic re-initialization on gaps. The fastest 
-way to access current order book depth without exceeding Binance rate limits. Manages multiple depth caches per 
-instance in asyncio coroutines.
+way to access current order book depth without exceeding Binance rate limits. Supports Spot, Futures, 
+**European Options (Vanilla Options)**, US and TR. Manages multiple depth caches per instance in asyncio coroutines.
 
 **220K+ downloads** | **49 stars**
 
@@ -99,7 +99,7 @@ programming language.
 ### [UNICORN Binance Trailing Stop Loss](https://github.com/oliver-zehentleitner/unicorn-binance-trailing-stop-loss) (UBTSL)
 Trailing stop loss engine with smart entry (`jump-in-and-trail`). Available as Python SDK and 
 [CLI tool](https://github.com/oliver-zehentleitner/unicorn-binance-trailing-stop-loss/tree/master/cli). 
-Supports email and Telegram notifications.
+Supports email notifications.
 
 **101K+ downloads** | **27 stars**
 

--- a/tools/get_versions_of_unicorn_packages.py
+++ b/tools/get_versions_of_unicorn_packages.py
@@ -76,6 +76,11 @@ try:
 except ModuleNotFoundError:
     ubwa_version = "not found"
 
+try:
+    from ubdcc import __version__ as ubdcc_version
+except (ModuleNotFoundError, ImportError):
+    ubdcc_version = "not found"
+
 
 print(f"Please post this to your github issue:")
 print(f"unicorn_fy: {unify_version}")
@@ -83,3 +88,4 @@ print(f"unicorn_binance_local_depth_cache: {ubldc_version}")
 print(f"unicorn_binance_rest_api: {ubra_version}")
 print(f"unicorn_binance_trailing_stop_loss: {ubtsl_version}")
 print(f"unicorn_binance_websocket_api: {ubwa_version}")
+print(f"ubdcc: {ubdcc_version}")


### PR DESCRIPTION
## Summary
- Added `ubdcc` version check to `tools/get_versions_of_unicorn_packages.py`
- Imports `ubdcc.__version__` and prints it alongside the other suite packages

## Test plan
- [ ] Run `python tools/get_versions_of_unicorn_packages.py` and verify ubdcc version is printed (or "not found" if not installed)