### PR TITLE
Add ubdcc to suite dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,11 +21,11 @@ repository = "https://github.com/oliver-zehentleitner/unicorn-binance-suite"
 
 [tool.poetry.dependencies]
 python = ">=3.9.0"
-unicorn-fy = ">=0.16.1"
-unicorn-binance-local-depth-cache = ">=1.0.0"
-unicorn-binance-rest-api = ">=2.8.0"
-unicorn-binance-websocket-api = ">=2.10.2"
-unicorn-binance-trailing-stop-loss = ">=1.0.0"
+unicorn-fy = ">=0.17.1"
+unicorn-binance-local-depth-cache = ">=2.12.1"
+unicorn-binance-rest-api = ">=2.10.0"
+unicorn-binance-websocket-api = ">=2.12.0"
+unicorn-binance-trailing-stop-loss = ">=1.3.0"
 ubdcc = ">=0.5.0"
 
 [tool.poetry.dev-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ unicorn-binance-local-depth-cache = ">=1.0.0"
 unicorn-binance-rest-api = ">=2.8.0"
 unicorn-binance-websocket-api = ">=2.10.2"
 unicorn-binance-trailing-stop-loss = ">=1.0.0"
+ubdcc = ">=0.5.0"
 
 [tool.poetry.dev-dependencies]
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,9 +4,9 @@
 # ./pyproject.toml
 # ./setup.py
 
-unicorn-fy>=0.16.1
-unicorn-binance-local-depth-cache>=2.8.0
-unicorn-binance-rest-api>=2.8.0
-unicorn-binance-trailing-stop-loss>=1.1.0
-unicorn-binance-websocket-api>=2.10.2
+unicorn-fy>=0.17.1
+unicorn-binance-local-depth-cache>=2.12.1
+unicorn-binance-rest-api>=2.10.0
+unicorn-binance-trailing-stop-loss>=1.3.0
+unicorn-binance-websocket-api>=2.12.0
 ubdcc>=0.5.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ unicorn-binance-local-depth-cache>=2.8.0
 unicorn-binance-rest-api>=2.8.0
 unicorn-binance-trailing-stop-loss>=1.1.0
 unicorn-binance-websocket-api>=2.10.2
+ubdcc>=0.5.0

--- a/setup.py
+++ b/setup.py
@@ -56,7 +56,7 @@ setup(
      license='MIT',
      install_requires=['unicorn-binance-websocket-api>=2.10.2', 'unicorn-binance-rest-api>=2.8.0',
                        'unicorn-fy>=0.16.1', 'unicorn-binance-local-depth-cache>=2.8.0',
-                       'unicorn-binance-trailing-stop-loss>=1.1.0'],
+                       'unicorn-binance-trailing-stop-loss>=1.1.0', 'ubdcc>=0.5.0'],
      keywords='Binance, Websocket, REST, Local Depth Cache, Trailing Stop Loss, Trading Bot, Algo Trading',
      project_urls={
         'Documentation': 'https://oliver-zehentleitner.github.io/unicorn-binance-suite/',

--- a/setup.py
+++ b/setup.py
@@ -54,9 +54,9 @@ setup(
      long_description=long_description,
      long_description_content_type="text/markdown",
      license='MIT',
-     install_requires=['unicorn-binance-websocket-api>=2.10.2', 'unicorn-binance-rest-api>=2.8.0',
-                       'unicorn-fy>=0.16.1', 'unicorn-binance-local-depth-cache>=2.8.0',
-                       'unicorn-binance-trailing-stop-loss>=1.1.0', 'ubdcc>=0.5.0'],
+     install_requires=['unicorn-binance-websocket-api>=2.12.0', 'unicorn-binance-rest-api>=2.10.0',
+                       'unicorn-fy>=0.17.1', 'unicorn-binance-local-depth-cache>=2.12.1',
+                       'unicorn-binance-trailing-stop-loss>=1.3.0', 'ubdcc>=0.5.0'],
      keywords='Binance, Websocket, REST, Local Depth Cache, Trailing Stop Loss, Trading Bot, Algo Trading',
      project_urls={
         'Documentation': 'https://oliver-zehentleitner.github.io/unicorn-binance-suite/',


### PR DESCRIPTION
## Summary
Add `ubdcc>=0.5.0` to setup.py, pyproject.toml and requirements.txt so that `pip install unicorn-binance-suite` also installs the DepthCache Cluster package.

Not added to environment.yml/meta.yaml since ubdcc is not on the lucit Conda channel.