### PR TITLE
README: add AI Integration section referencing llms.txt

### DIFF
--- a/README.md
+++ b/README.md
@@ -318,6 +318,14 @@ for guidelines.
 
 ---
 
+## AI Integration
+
+This project provides [`llms.txt`](llms.txt) files for AI tools (ChatGPT, Claude, Copilot, etc.). The 
+[suite-level llms.txt](llms.txt) routes use cases to the correct module. Each module also has its own `llms.txt` with 
+detailed API reference and code examples.
+
+---
+
 ## Disclaimer
 
 This project is for informational purposes only. Nothing contained herein constitutes financial advice or a 


### PR DESCRIPTION
## Summary

- Adds an "AI Integration" section to README.md before the Disclaimer, referencing the suite-level `llms.txt` file
- Describes the routing hub role of the suite `llms.txt` and points to per-module `llms.txt` files

## Test plan

- [ ] Verify the new section renders correctly on GitHub
- [ ] Confirm links to `llms.txt` resolve properly