### PR TITLE
llms.txt: add docs block and explicit module repo list

### DIFF
--- a/llms.txt
+++ b/llms.txt
@@ -2,6 +2,22 @@
 
 > The production-grade Python toolkit for Binance. MIT-licensed.
 
+Python 3.9 – 3.14.
+
+Suite:
+- Repo: https://github.com/oliver-zehentleitner/unicorn-binance-suite
+- Docs: https://oliver-zehentleitner.github.io/unicorn-binance-suite/
+- PyPI: https://pypi.org/project/unicorn-binance-suite/
+- conda-forge: https://anaconda.org/conda-forge/unicorn-binance-suite
+
+Module repositories (all under `oliver-zehentleitner/`):
+- UBWA: https://github.com/oliver-zehentleitner/unicorn-binance-websocket-api
+- UBRA: https://github.com/oliver-zehentleitner/unicorn-binance-rest-api
+- UBLDC: https://github.com/oliver-zehentleitner/unicorn-binance-local-depth-cache
+- UBDCC: https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster
+- UBTSL: https://github.com/oliver-zehentleitner/unicorn-binance-trailing-stop-loss
+- UnicornFy: https://github.com/oliver-zehentleitner/unicorn-fy
+
 Install: `pip install unicorn-binance-suite`
 
 ## Use Case → Module Routing


### PR DESCRIPTION
Addresses a review note from claude.ai on the current `llms.txt`:

- Added a `Suite:` block with explicit Repo / Docs / PyPI / conda-forge URLs so an LLM has one place to resolve those without having to guess.
- Enumerated all six module repositories explicitly under `Module repositories` — the set is stable and LLM consumers can grep it without fetching the docs site.
- Stated the Python support range (`3.9 – 3.14`) up front.

No layout changes to the existing sections (Use Case Routing, Canonical Example, Supported Exchanges, Key Design Principles, Per-Module Documentation).