### PR TITLE
Bump suite dependency minimums to the cleanup-round releases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,15 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 ## 2.1.0.dev (development stage/unreleased/unstable)
 ### Changed
+- Bumped suite dependency minimums to the cleanup-round releases:
+  - `unicorn-fy >= 0.17.2`
+  - `unicorn-binance-rest-api >= 2.11.0`
+  - `unicorn-binance-websocket-api >= 2.12.2`
+  - `unicorn-binance-local-depth-cache >= 2.12.2`
+  - `unicorn-binance-trailing-stop-loss >= 1.3.1`
+
+  (`ubdcc` stays at `>= 0.5.0`.) Synced across `setup.py`,
+  `pyproject.toml` and `requirements.txt`.
 - `meta.yaml`: switched conda deps from the legacy `lucit::` channel
   prefixes to conda-forge. Removed the leftover `channels:` and
   `dependencies:` blocks (they are `environment.yml` keys, not valid

--- a/environment.yml
+++ b/environment.yml
@@ -5,8 +5,8 @@ channels:
 
 dependencies:
   - python>=3.9
-  - unicorn-fy
-  - unicorn-binance-local-depth-cache
-  - unicorn-binance-rest-api
-  - unicorn-binance-trailing-stop-loss
-  - unicorn-binance-websocket-api
+  - unicorn-fy>=0.17.2
+  - unicorn-binance-local-depth-cache>=2.12.2
+  - unicorn-binance-rest-api>=2.11.0
+  - unicorn-binance-trailing-stop-loss>=1.3.1
+  - unicorn-binance-websocket-api>=2.12.2

--- a/meta.yaml
+++ b/meta.yaml
@@ -19,11 +19,11 @@ requirements:
     - pip
   run:
     - python >=3.9
-    - unicorn-fy
-    - unicorn-binance-local-depth-cache
-    - unicorn-binance-rest-api
-    - unicorn-binance-trailing-stop-loss
-    - unicorn-binance-websocket-api
+    - unicorn-fy >=0.17.2
+    - unicorn-binance-local-depth-cache >=2.12.2
+    - unicorn-binance-rest-api >=2.11.0
+    - unicorn-binance-trailing-stop-loss >=1.3.1
+    - unicorn-binance-websocket-api >=2.12.2
 
 test:
   imports:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,11 +21,11 @@ repository = "https://github.com/oliver-zehentleitner/unicorn-binance-suite"
 
 [tool.poetry.dependencies]
 python = ">=3.9.0"
-unicorn-fy = ">=0.17.1"
-unicorn-binance-local-depth-cache = ">=2.12.1"
-unicorn-binance-rest-api = ">=2.10.0"
-unicorn-binance-websocket-api = ">=2.12.0"
-unicorn-binance-trailing-stop-loss = ">=1.3.0"
+unicorn-fy = ">=0.17.2"
+unicorn-binance-local-depth-cache = ">=2.12.2"
+unicorn-binance-rest-api = ">=2.11.0"
+unicorn-binance-websocket-api = ">=2.12.2"
+unicorn-binance-trailing-stop-loss = ">=1.3.1"
 ubdcc = ">=0.5.0"
 
 [tool.poetry.dev-dependencies]

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,9 +4,9 @@
 # ./pyproject.toml
 # ./setup.py
 
-unicorn-fy>=0.17.1
-unicorn-binance-local-depth-cache>=2.12.1
-unicorn-binance-rest-api>=2.10.0
-unicorn-binance-trailing-stop-loss>=1.3.0
-unicorn-binance-websocket-api>=2.12.0
+unicorn-fy>=0.17.2
+unicorn-binance-local-depth-cache>=2.12.2
+unicorn-binance-rest-api>=2.11.0
+unicorn-binance-trailing-stop-loss>=1.3.1
+unicorn-binance-websocket-api>=2.12.2
 ubdcc>=0.5.0

--- a/setup.py
+++ b/setup.py
@@ -54,9 +54,9 @@ setup(
      long_description=long_description,
      long_description_content_type="text/markdown",
      license='MIT',
-     install_requires=['unicorn-binance-websocket-api>=2.12.0', 'unicorn-binance-rest-api>=2.10.0',
-                       'unicorn-fy>=0.17.1', 'unicorn-binance-local-depth-cache>=2.12.1',
-                       'unicorn-binance-trailing-stop-loss>=1.3.0', 'ubdcc>=0.5.0'],
+     install_requires=['unicorn-binance-websocket-api>=2.12.2', 'unicorn-binance-rest-api>=2.11.0',
+                       'unicorn-fy>=0.17.2', 'unicorn-binance-local-depth-cache>=2.12.2',
+                       'unicorn-binance-trailing-stop-loss>=1.3.1', 'ubdcc>=0.5.0'],
      keywords='Binance, Websocket, REST, Local Depth Cache, Trailing Stop Loss, Trading Bot, Algo Trading',
      project_urls={
         'Documentation': 'https://oliver-zehentleitner.github.io/unicorn-binance-suite/',


### PR DESCRIPTION
After the full cleanup release round, bumping the suite's minimum dependency pins:

| Package | Old | New |
|---|---|---|
| unicorn-fy | >=0.17.1 | **>=0.17.2** |
| unicorn-binance-rest-api | >=2.10.0 | **>=2.11.0** |
| unicorn-binance-websocket-api | >=2.12.0 | **>=2.12.2** |
| unicorn-binance-local-depth-cache | >=2.12.1 | **>=2.12.2** |
| unicorn-binance-trailing-stop-loss | >=1.3.0 | **>=1.3.1** |
| ubdcc | >=0.5.0 | unchanged |

Synced across `setup.py`, `pyproject.toml` and `requirements.txt`. `environment.yml` + `meta.yaml` are owned by the open lucit-cleanup PR #43 — those will get the same bumps once that one merges (or I'll rebase here).