### PR TITLE
README: point Conda-Forge badge at GHA, not Azure

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 [![Supported Python Version](https://img.shields.io/pypi/pyversions/unicorn_binance_suite.svg)](https://www.python.org/downloads/)
 [![Unit Tests](https://github.com/oliver-zehentleitner/unicorn-binance-suite/actions/workflows/unit-tests.yml/badge.svg)](https://github.com/oliver-zehentleitner/unicorn-binance-suite/actions/workflows/unit-tests.yml)
 [![Build and Publish GH+PyPi](https://github.com/oliver-zehentleitner/unicorn-binance-suite/actions/workflows/build_wheels.yml/badge.svg)](https://github.com/oliver-zehentleitner/unicorn-binance-suite/actions/workflows/build_wheels.yml)
-[![Conda-Forge Build](https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/unicorn-binance-suite-feedstock?branchName=main)](https://github.com/conda-forge/unicorn-binance-suite-feedstock)
+[![Conda-Forge Build](https://github.com/conda-forge/unicorn-binance-suite-feedstock/actions/workflows/conda-build.yml/badge.svg?branch=main)](https://github.com/conda-forge/unicorn-binance-suite-feedstock/actions/workflows/conda-build.yml)
 [![Read the Docs](https://img.shields.io/badge/read-%20docs-yellow)](https://oliver-zehentleitner.github.io/unicorn-binance-suite/)
 [![Telegram](https://img.shields.io/badge/community-telegram-41ab8c)](https://t.me/unicorndevs)
 


### PR DESCRIPTION
## Problem

The `Conda-Forge Build` badge in the README permanently shows
**"never built"**, even after fresh releases.

## Cause

`unicorn-binance-suite` is a pure Python meta-package (`noarch:
python`). conda-forge runs single-build noarch feedstocks **only on
GitHub Actions**; Azure Pipelines is activated only for multi-platform
build matrices. So the Azure pipeline the badge was pointing at
(`dev.azure.com/conda-forge/feedstock-builds/.../unicorn-binance-suite-feedstock`)
simply never runs for this feedstock — nothing to report → "never
built".

Confirmed in the feedstock: only `.github/workflows/conda-build.yml`
exists, no `azure-pipelines.yml`.

## Fix

Point the badge at the feedstock's GHA workflow:

```
https://github.com/conda-forge/unicorn-binance-suite-feedstock/actions/workflows/conda-build.yml/badge.svg?branch=main
```

## Scope

Only affects this repo. The other UBS feedstocks
(UBLDC / UBWA / UBRA / UBTSL / unicorn-fy) are Cython-compiled
multi-platform builds and correctly keep their Azure badges.