### PR TITLE
README: add conda install snippet to top section

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,12 @@ Cython C extensions. Available via [PyPI](https://pypi.org/project/unicorn-binan
 pip install unicorn-binance-suite
 ```
 
+Or via conda (UBDCC not included — install separately via `pip install ubdcc`):
+
+```
+conda install -c conda-forge unicorn-binance-suite
+```
+
 **2.8 M+ PyPI downloads** | **980+ GitHub stars** | **388+ dependent projects** | Python 3.9 -- 3.14
 
 ---

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Cython C extensions. Available via [PyPI](https://pypi.org/project/unicorn-binan
 pip install unicorn-binance-suite
 ```
 
-Or via conda (UBDCC not included — install separately via `pip install ubdcc`):
+Or via conda ([UBDCC](https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster) not included — install separately via `pip install ubdcc`):
 
 ```
 conda install -c conda-forge unicorn-binance-suite


### PR DESCRIPTION
## Summary
- Adds a conda install example right under the top-level pip install snippet
- Notes that UBDCC is not part of the conda meta-package (install separately via `pip install ubdcc`)

## Test plan
- [x] Markdown renders correctly (fenced code blocks, no broken links)
- [x] Info matches `meta.yaml` (no `ubdcc` in conda requirements)