### PR TITLE
TASKS: add conda-forge URL to all file headers

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -18,6 +18,10 @@ Once all four feedstocks have `migrations/python314.yaml` + py3.14 variants buil
 ### [ ] README: add "Start here / Choose the right module" block at the very top
 Before the competitor comparison table, add a short decision block so a first-time visitor instantly knows which sub-package they need. Template available in `llms.txt` (`## Use Case → Module Routing` table — one-liner per module). Suggested placement: directly after the install snippet, before the "Why UBS" comparison.
 
+### [ ] File headers: add conda-forge URL in all modules
+The standard per-file header block (`Project website`, `Github`, `Documentation`, `PyPI`) is missing a line for the conda-forge package. Add a consistent
+`# Conda-Forge: https://anaconda.org/conda-forge/<package-name>` line right below the `PyPI` line in every `.py` file across all suite modules (UBWA, UBRA, UBLDC, UBTSL, UBDCC packages, UBS-Meta, UnicornFy).
+
 ### [ ] Check for Python 3.15 support (November 2026)
 CPython 3.15 is scheduled for release in October 2026 ([PEP 790](https://peps.python.org/pep-0790/)).
 conda-forge typically adds a new Python version to the global pinning 1–2 months after the CPython release,


### PR DESCRIPTION
## Summary
- New backlog item: add a \`# Conda-Forge: https://anaconda.org/conda-forge/<package-name>\` line below the existing \`PyPI\` line in the standard file-header block of every \`.py\` file across all suite modules.