### PR TITLE
Add UBDCC Dashboard as a new tool in the suite

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ conda install -c conda-forge unicorn-binance-suite
 | **[Orphan level cleanup (>1000)](https://blog.technopathy.club/your-binance-order-book-is-wrong-here-s-why)**                                                                                    | Implemented — strictly follows Binance spec | No — delivers inconsistent books | No | N/A |
 | **DepthCache refresh**                                                                                                                                                                           | Event-driven, same asyncio loop as the stream | **REST polling every 30 min** (default) — not truly "live local" | Cache via Pro license | Not available |
 | **DepthCache cluster**                                                                                                                                                                           | **UBDCC** — horizontally scalable, load balancing, failover, REST API | — | — | — |
+| **Live cluster dashboard**                                                                                                                                                                       | **UBDCC Dashboard** — browser UI, CLI-launched, MIT | — | — | — |
 | **Trailing stop loss**                                                                                                                                                                           | **UBTSL** as SDK + CLI, incl. `jump-in-and-trail` | Not included | Not included | Not included |
 | **Performance**                                                                                                                                                                                  | Cython C extensions, PyPy wheels, pre-compiled | Pure Python, no C | Pure Python — [reported performance issues](https://github.com/ccxt/ccxt/issues/25152) with many symbols | Pure Python |
 | **Multi-arch wheels**                                                                                                                                                                            | x86_64, aarch64, arm64, PyPy | Mostly x86_64 | Pure Python | Pure Python |
@@ -148,6 +149,12 @@ Production-scale depth cache management with load balancing, automatic failover 
 or [scales across a Kubernetes cluster](https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster?tab=readme-ov-file#kubernetes-setup). 
 [REST API](https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster?tab=readme-ov-file#rest-api) 
 accessible from any programming language.
+
+### [UBDCC Dashboard](https://github.com/oliver-zehentleitner/ubdcc-dashboard)
+Browser-based live dashboard for monitoring and managing a running UBDCC cluster. Compact mini-orderbook tiles per 
+depth cache, desync/error highlighting, add or remove caches on the fly. Ships as a pip-installable CLI 
+(`pip install ubdcc-dashboard` → `ubdcc-dashboard start`) serving a single-file vanilla-JS UI through a tiny stdlib 
+HTTP + CORS-proxy server. Localhost-only by default, opt-in network exposure via `--host`.
 
 ### [UNICORN Binance Trailing Stop Loss](https://github.com/oliver-zehentleitner/unicorn-binance-trailing-stop-loss) (UBTSL)
 Trailing stop loss engine with smart entry (`jump-in-and-trail`). Available as Python SDK and 
@@ -304,6 +311,7 @@ is traceable.
 | UBRA (REST) | [oliver-zehentleitner.github.io/unicorn-binance-rest-api](https://oliver-zehentleitner.github.io/unicorn-binance-rest-api) |
 | UBLDC (Depth Cache) | [oliver-zehentleitner.github.io/unicorn-binance-local-depth-cache](https://oliver-zehentleitner.github.io/unicorn-binance-local-depth-cache) |
 | UBDCC (Depth Cache Cluster) | [oliver-zehentleitner.github.io/unicorn-binance-depth-cache-cluster](https://oliver-zehentleitner.github.io/unicorn-binance-depth-cache-cluster) |
+| UBDCC Dashboard | [oliver-zehentleitner.github.io/ubdcc-dashboard](https://oliver-zehentleitner.github.io/ubdcc-dashboard) |
 | UBTSL (Trailing Stop) | [oliver-zehentleitner.github.io/unicorn-binance-trailing-stop-loss](https://oliver-zehentleitner.github.io/unicorn-binance-trailing-stop-loss) |
 | UnicornFy | [oliver-zehentleitner.github.io/unicorn-fy](https://oliver-zehentleitner.github.io/unicorn-fy) |
 

--- a/llms.txt
+++ b/llms.txt
@@ -25,6 +25,7 @@ Module repositories (all under `oliver-zehentleitner/`):
 - UBRA: https://github.com/oliver-zehentleitner/unicorn-binance-rest-api
 - UBLDC: https://github.com/oliver-zehentleitner/unicorn-binance-local-depth-cache
 - UBDCC: https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster
+- UBDCC Dashboard: https://github.com/oliver-zehentleitner/ubdcc-dashboard
 - UBTSL: https://github.com/oliver-zehentleitner/unicorn-binance-trailing-stop-loss
 - UnicornFy: https://github.com/oliver-zehentleitner/unicorn-fy
 
@@ -38,6 +39,7 @@ Install: `pip install unicorn-binance-suite`
 | Place orders, query account via REST | UBRA | `pip install unicorn-binance-rest-api` | `from unicorn_binance_rest_api import BinanceRestApiManager` |
 | Maintain a local order book (depth cache) | UBLDC | `pip install unicorn-binance-local-depth-cache` | `from unicorn_binance_local_depth_cache import BinanceLocalDepthCacheManager` |
 | Run a scalable depth cache cluster | UBDCC | `pip install ubdcc` | CLI: `ubdcc start` / Python: via UBLDC cluster attribute |
+| Monitor a running UBDCC cluster in the browser | UBDCC Dashboard | `pip install ubdcc-dashboard` | CLI: `ubdcc-dashboard start` (no Python API — browser UI only) |
 | Trail a stop loss order | UBTSL | `pip install unicorn-binance-trailing-stop-loss` | `from unicorn_binance_trailing_stop_loss import BinanceTrailingStopLossManager` |
 | Normalize raw exchange data to dicts | UnicornFy | `pip install unicorn-fy` | `from unicorn_fy import UnicornFy` |
 
@@ -87,5 +89,6 @@ Each module has its own `llms.txt` with detailed API reference:
 - [UBRA llms.txt](https://raw.githubusercontent.com/oliver-zehentleitner/unicorn-binance-rest-api/refs/heads/master/llms.txt)
 - [UBLDC llms.txt](https://raw.githubusercontent.com/oliver-zehentleitner/unicorn-binance-local-depth-cache/refs/heads/master/llms.txt)
 - [UBDCC llms.txt](https://raw.githubusercontent.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster/refs/heads/master/llms.txt)
+- [UBDCC Dashboard llms.txt](https://raw.githubusercontent.com/oliver-zehentleitner/ubdcc-dashboard/refs/heads/master/llms.txt)
 - [UBTSL llms.txt](https://raw.githubusercontent.com/oliver-zehentleitner/unicorn-binance-trailing-stop-loss/refs/heads/master/llms.txt)
 - [UnicornFy llms.txt](https://raw.githubusercontent.com/oliver-zehentleitner/unicorn-fy/refs/heads/master/llms.txt)


### PR DESCRIPTION
## Summary

Lists the [ubdcc-dashboard](https://github.com/oliver-zehentleitner/ubdcc-dashboard) project alongside the other suite modules.

**README.md**
- New entry in the `## Modules` section, placed directly after UBDCC (thematically related — the dashboard is a client for UBDCC).
- New row in the `Why UNICORN Binance Suite — the honest comparison` table (Live cluster dashboard).
- New row in the `## Documentation` table.

**llms.txt**
- New entry in the `Module repositories` block.
- New row in the `Use Case → Module Routing` table ("Monitor a running UBDCC cluster in the browser").
- New link in the `Per-Module Documentation` block.

## Not touched

- Not added as a dependency of the `unicorn-binance-suite` meta package. The dashboard remains an optional separate install via `pip install ubdcc-dashboard`, exactly like UBDCC itself (not bundled either).
- `dev/sphinx/`, `docs/`, `meta.yaml` left alone — these regenerate from README.md per the repo's docs-autogen workflow.

## Test plan

- [ ] New module entry renders in the Modules list of the rendered README
- [ ] Why-UBS table shows the new row between DepthCache cluster and Trailing stop loss
- [ ] Documentation table lists the dashboard between UBDCC and UBTSL
- [ ] llms.txt changes are picked up by agents fetching the suite-level file