### PR TITLE
docs(sphinx): add UBDCC Dashboard to docs index page

### DIFF
--- a/dev/sphinx/source/docs_index.md
+++ b/dev/sphinx/source/docs_index.md
@@ -8,4 +8,5 @@
 | UNICORN Binance Local Depth Cache | [https://oliver-zehentleitner.github.io/unicorn-binance-local-depth-cache](https://oliver-zehentleitner.github.io/unicorn-binance-local-depth-cache) |
 | UNICORN Binance Trailing Stop Loss | [https://oliver-zehentleitner.github.io/unicorn-binance-trailing-stop-loss](https://oliver-zehentleitner.github.io/unicorn-binance-trailing-stop-loss) |
 | UNICORN Binance DepthCache Cluster | [https://oliver-zehentleitner.github.io/unicorn-binance-depth-cache-cluster/](https://oliver-zehentleitner.github.io/unicorn-binance-depth-cache-cluster/) |
+| UBDCC Dashboard | [https://oliver-zehentleitner.github.io/ubdcc-dashboard](https://oliver-zehentleitner.github.io/ubdcc-dashboard) |
 | UnicornFy | [https://oliver-zehentleitner.github.io/unicorn-fy](https://oliver-zehentleitner.github.io/unicorn-fy) |


### PR DESCRIPTION
## Summary
- The sphinx documentation index (`dev/sphinx/source/docs_index.md`) lists the GitHub Pages docs URL of every module in the suite
- UBDCC Dashboard was missing from that table — added a row linking to https://oliver-zehentleitner.github.io/ubdcc-dashboard
- README.md already links the dashboard docs (added in #57); this closes the same gap on the sphinx side

## Test plan
- [ ] Visually verify the new row renders on the generated docs index page after the next docs build