### PR TITLE
docs(readme): Dashboard is not just monitoring -- also management

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,7 +240,7 @@ with BinanceLocalDepthCacheManager(exchange="binance.com", ubdcc_address="127.0.
 [Kubernetes cluster](https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster?tab=readme-ov-file#kubernetes-setup).
 [REST API](https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster?tab=readme-ov-file#rest-api) accessible from any language.
 
-### Monitor a DepthCache cluster in the browser
+### Monitor and manage a DepthCache cluster in the browser
 ```sh
 # use case: live browser UI for a running UBDCC cluster
 # module: ubdcc-dashboard (CLI only, no Python API)


### PR DESCRIPTION
## Summary
- Follow-up to #59: the Common Use Cases heading 'Monitor a DepthCache cluster in the browser' under-sold the Dashboard
- Dashboard is not read-only — it can also add/remove depth caches on the fly and manage the cluster
- Changed heading to 'Monitor and manage a DepthCache cluster in the browser'. The block body already mentions add/remove, only the heading was misleading

## Test plan
- [ ] Rendered README shows the new heading wording