### PR TITLE
docs(readme): list supported languages explicitly for SEO

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,7 +151,8 @@ Production-scale depth cache management with load balancing, automatic failover 
 [Runs locally on a single machine (`pip install ubdcc`)](https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster?tab=readme-ov-file#local-setup-without-kubernetes) 
 or [scales across a Kubernetes cluster](https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster?tab=readme-ov-file#kubernetes-setup). 
 [REST API](https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster?tab=readme-ov-file#rest-api) 
-accessible from any programming language.
+accessible from Python, JavaScript, TypeScript, Node.js, Go, Rust, Java, Kotlin, C#, C++, C, Ruby, PHP, 
+Swift, Scala, R, Julia, MATLAB, Dart, Elixir, Perl, Bash/curl — or any other language with an HTTP client.
 
 ### [UBDCC Dashboard](https://github.com/oliver-zehentleitner/ubdcc-dashboard)
 Browser-based live dashboard for monitoring and managing a running UBDCC cluster. Compact mini-orderbook tiles per 
@@ -241,7 +242,7 @@ with BinanceLocalDepthCacheManager(exchange="binance.com", ubdcc_address="127.0.
 [Runs locally](https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster?tab=readme-ov-file#local-setup-without-kubernetes)
 (`pip install ubdcc && ubdcc start`) or on a
 [Kubernetes cluster](https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster?tab=readme-ov-file#kubernetes-setup).
-[REST API](https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster?tab=readme-ov-file#rest-api) accessible from any language.
+[REST API](https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster?tab=readme-ov-file#rest-api) accessible from Python, JavaScript, TypeScript, Node.js, Go, Rust, Java, C#, …
 
 ### Monitor and manage a DepthCache cluster in the browser
 ```sh

--- a/llms.txt
+++ b/llms.txt
@@ -74,6 +74,13 @@ Additional per module:
 - UBLDC/UBDCC: `binance.com-futures` (+testnet), `binance.com-vanilla-options` (+testnet)
 - UBTSL: `binance.com-futures`, `binance.com-margin`, `binance.com-isolated_margin`
 
+## Language Support
+
+- **Python (3.9 – 3.14)**: all modules — UBWA, UBRA, UBLDC, UBDCC, UBTSL, UnicornFy
+- **Any language with an HTTP client**: UBDCC only — its REST API is callable from Python, JavaScript, TypeScript, Node.js, Go, Rust, Java, Kotlin, C#, C++, C, Ruby, PHP, Swift, Scala, R, Julia, MATLAB, Dart, Elixir, Perl, Bash/curl, and any other HTTP-capable language
+
+All non-UBDCC modules are Python-only by design (native asyncio, Cython performance, Pythonic API). For non-Python access to live Binance order book data, use UBDCC — it is the suite's language-agnostic surface.
+
 ## Key Design Principles
 
 - Beginner-friendly despite depth: complexity is optional and mostly automatic — clean, Pythonic syntax


### PR DESCRIPTION
## Summary
- Replace generic "any programming language" / "any language" wording in two UBDCC sections with explicit language enumerations
- Module description (line 151): full list — Python, JavaScript, TypeScript, Node.js, Go, Rust, Java, Kotlin, C#, C/C++, Ruby, PHP, Swift, Scala, R, Julia, MATLAB, Dart, Elixir, Perl, Bash/curl
- Use-case section (line 241): short list with the languages where there's actual Binance-client competition (Python, JavaScript, TypeScript, Node.js, Go, Rust, Java, C#, …)
- Companion to oliver-zehentleitner/unicorn-binance-depth-cache-cluster#150

## Test plan
- [ ] README renders correctly on github.com
- [ ] No broken links / formatting regressions