### PR TITLE
chore: bump copyright year to 2026

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,7 +1,7 @@
 MIT License
 ===========
 
-Copyright (c) 2019-2025 Oliver Zehentleitner, https://about.me/oliver-zehentleitner
+Copyright (c) 2019-2026 Oliver Zehentleitner, https://about.me/oliver-zehentleitner
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/dev/pypi/create_wheel.sh
+++ b/dev/pypi/create_wheel.sh
@@ -14,7 +14,7 @@
 #
 # Author: Oliver Zehentleitner
 #
-# Copyright (c) 2019-2025, Oliver Zehentleitner (https://about.me/oliver-zehentleitner)
+# Copyright (c) 2019-2026, Oliver Zehentleitner (https://about.me/oliver-zehentleitner)
 #
 # All rights reserved.
 #

--- a/dev/pypi/install_packaging_tools.sh
+++ b/dev/pypi/install_packaging_tools.sh
@@ -14,7 +14,7 @@
 #
 # Author: Oliver Zehentleitner
 #
-# Copyright (c) 2019-2025, Oliver Zehentleitner (https://about.me/oliver-zehentleitner)
+# Copyright (c) 2019-2026, Oliver Zehentleitner (https://about.me/oliver-zehentleitner)
 #
 # All rights reserved.
 #

--- a/dev/pypi/remove_files.sh
+++ b/dev/pypi/remove_files.sh
@@ -14,7 +14,7 @@
 #
 # Author: Oliver Zehentleitner
 #
-# Copyright (c) 2019-2025, Oliver Zehentleitner (https://about.me/oliver-zehentleitner)
+# Copyright (c) 2019-2026, Oliver Zehentleitner (https://about.me/oliver-zehentleitner)
 #
 # All rights reserved.
 #

--- a/dev/pypi/upload_wheel.sh
+++ b/dev/pypi/upload_wheel.sh
@@ -14,7 +14,7 @@
 #
 # Author: Oliver Zehentleitner
 #
-# Copyright (c) 2019-2025, Oliver Zehentleitner (https://about.me/oliver-zehentleitner)
+# Copyright (c) 2019-2026, Oliver Zehentleitner (https://about.me/oliver-zehentleitner)
 #
 # All rights reserved.
 #

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@
 #
 # Author: Oliver Zehentleitner
 #
-# Copyright (c) 2019-2025, Oliver Zehentleitner (https://about.me/oliver-zehentleitner)
+# Copyright (c) 2019-2026, Oliver Zehentleitner (https://about.me/oliver-zehentleitner)
 #
 # All rights reserved.
 #

--- a/tools/get_versions_of_unicorn_packages.py
+++ b/tools/get_versions_of_unicorn_packages.py
@@ -11,7 +11,7 @@
 #
 # Author: Oliver Zehentleitner
 #
-# Copyright (c) 2022-2025, Oliver Zehentleitner (https://about.me/oliver-zehentleitner)
+# Copyright (c) 2022-2026, Oliver Zehentleitner (https://about.me/oliver-zehentleitner)
 # All rights reserved.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a

--- a/unicorn_binance_suite/manager.py
+++ b/unicorn_binance_suite/manager.py
@@ -14,7 +14,7 @@
 #
 # Author: Oliver Zehentleitner
 #
-# Copyright (c) 2019-2025, Oliver Zehentleitner (https://about.me/oliver-zehentleitner)
+# Copyright (c) 2019-2026, Oliver Zehentleitner (https://about.me/oliver-zehentleitner)
 #
 # All rights reserved.
 #

--- a/unittest_binance_suite.py
+++ b/unittest_binance_suite.py
@@ -14,7 +14,7 @@
 #
 # Author: Oliver Zehentleitner
 #
-# Copyright (c) 2019-2025, Oliver Zehentleitner (https://about.me/oliver-zehentleitner)
+# Copyright (c) 2019-2026, Oliver Zehentleitner (https://about.me/oliver-zehentleitner)
 #
 # All rights reserved.
 #


### PR DESCRIPTION
## Summary
- Bump copyright year from 2025 to 2026 in LICENSE + source headers
- Pattern: only modify lines containing \`Copyright\` to avoid touching unrelated 2025 occurrences (versions, dates, etc.)
- Auto-generated files (\`docs/\`, \`dev/sphinx/\`) intentionally untouched — regenerated on next build

## Test plan
- [ ] LICENSE shows 2019-2026
- [ ] No unintended 2025→2026 changes in non-copyright lines