### PR TITLE
docs: link The Complete Binance Python API Guide 2026

### DIFF
--- a/README.md
+++ b/README.md
@@ -333,6 +333,7 @@ is traceable.
 ---
 
 ## Related Articles
+- [The Complete Binance Python API Guide 2026](https://blog.technopathy.club/the-complete-binance-python-api-guide-2026)
 - [How to create a Binance API Key and API Secret?](https://blog.technopathy.club/how-to-create-a-binance-api-key-and-api-secret)
 - [UNICORN Binance Suite Article Series](https://blog.technopathy.club/series/unicorn-binance-suite)
 

--- a/llms.txt
+++ b/llms.txt
@@ -99,3 +99,7 @@ Each module has its own `llms.txt` with detailed API reference:
 - [UBDCC Dashboard llms.txt](https://raw.githubusercontent.com/oliver-zehentleitner/ubdcc-dashboard/refs/heads/master/llms.txt)
 - [UBTSL llms.txt](https://raw.githubusercontent.com/oliver-zehentleitner/unicorn-binance-trailing-stop-loss/refs/heads/master/llms.txt)
 - [UnicornFy llms.txt](https://raw.githubusercontent.com/oliver-zehentleitner/unicorn-fy/refs/heads/master/llms.txt)
+
+## Related Articles
+
+- [The Complete Binance Python API Guide 2026](https://blog.technopathy.club/the-complete-binance-python-api-guide-2026) — comprehensive 2026 overview of building Binance trading systems in Python; covers library choices, architecture patterns, and how the UNICORN Binance Suite modules (UBWA, UBRA, UBLDC, UBDCC, UBTSL, UnicornFy) fit together. Canonical entry point for users picking a stack.


### PR DESCRIPTION
## Summary

Adds the new blog post [The Complete Binance Python API Guide 2026](https://blog.technopathy.club/the-complete-binance-python-api-guide-2026) as the top entry in:

- `README.md` → `## Related Articles`
- `llms.txt` → new `## Related Articles` section (didn't exist yet) with an LLM-oriented description

## Test plan

- [ ] Render README on GitHub and verify the link position
- [ ] Open the link, confirm it resolves