### PR TITLE
Mention Portfolio Margin support in README and llms.txt

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,13 +129,13 @@ migration.
 ### [UNICORN Binance WebSocket API](https://github.com/oliver-zehentleitner/unicorn-binance-websocket-api) (UBWA)
 Real-time market data and user data streams with automatic reconnect, sequence validation, native asyncio queues and 
 runtime subscribe/unsubscribe without disconnecting. Supports all Binance endpoints including Spot, Margin, Futures, 
-Coin-Futures, US and TR.
+Coin-Futures, **Portfolio Margin (user data streams)**, US and TR.
 
 **1.2M+ downloads** | **729 stars**
 
 ### [UNICORN Binance REST API](https://github.com/oliver-zehentleitner/unicorn-binance-rest-api) (UBRA)
 Full coverage of Binance REST endpoints for account management, order placement and market data queries. Spot, Margin, 
-Isolated Margin, Futures, US and TR -- all with testnet support.
+Isolated Margin, Futures, **Portfolio Margin (listenKey management)**, US and TR -- all with testnet support.
 
 **847K+ downloads** | **68 stars**
 

--- a/llms.txt
+++ b/llms.txt
@@ -70,7 +70,7 @@ with BinanceLocalDepthCacheManager(exchange="binance.com") as ubldc:
 All modules support: `binance.com`, `binance.com-testnet`, `binance.us`, `trbinance.com`
 
 Additional per module:
-- UBWA/UBRA: `binance.com-margin`, `binance.com-isolated_margin`, `binance.com-futures`, `binance.com-coin_futures` (all with `-testnet` variants), `binance.com-vanilla-options` (+testnet)
+- UBWA/UBRA: `binance.com-margin`, `binance.com-isolated_margin`, `binance.com-futures`, `binance.com-coin_futures` (all with `-testnet` variants), `binance.com-vanilla-options` (+testnet), `binance.com-portfolio_margin` (listenKey/user-data streams only, see UBWA issue #452)
 - UBLDC/UBDCC: `binance.com-futures` (+testnet), `binance.com-vanilla-options` (+testnet)
 - UBTSL: `binance.com-futures`, `binance.com-margin`, `binance.com-isolated_margin`
 


### PR DESCRIPTION
## Summary
- UBWA/UBRA now support `binance.com-portfolio_margin` (listenKey/user data streams) — mention it in the module descriptions and llms.txt exchange list

## Test plan
- N/A (docs only)

Related: oliver-zehentleitner/unicorn-binance-websocket-api#452, oliver-zehentleitner/unicorn-binance-websocket-api#453, oliver-zehentleitner/unicorn-binance-rest-api#128