### PR TITLE
Add Keep the Why setup: context/, config block, badge

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -106,3 +106,5 @@ venv.bak/
 # mypy
 .mypy_cache/
 CLAUDE.md
+
+AGENTS.local.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,6 +3,10 @@
 > **End-user cheatsheet for AI-assisted consumption:** [`llms.txt`](llms.txt) — use that one if you're writing code *against* the suite.
 > **This file** is for AI agents working *on* the suite repos themselves.
 
+## Why things are the way they are
+
+See [`context/index.md`](context/index.md) before making non-trivial changes — it points to the reasoning behind design decisions, rejected alternatives, and constraints that aren't visible in the code. If `AGENTS.local.md` exists in this repo, that's personal/local notes, not relevant to anyone else.
+
 ## Planning & Backlog
 
 Suite-wide tasks and decisions are tracked in **[TASKS.md](TASKS.md)**. Per-module tasks live in the respective module repo's `TASKS.md`.
@@ -50,7 +54,7 @@ dev/sphinx/               # Sphinx source
 
 ## Dependencies
 
-Managed in `requirements.txt`, `setup.py`, `pyproject.toml`, `environment.yml` and `meta.yaml` — **all five must be kept in sync manually**, with `setup.py` as source of truth.
+Managed in `requirements.txt`, `setup.py`, `pyproject.toml`, `environment.yml` and `meta.yaml` — all five kept in sync manually, with `setup.py` as source of truth. Why five files, and the pin-timing rule: [`context/dependency-management.md`](context/dependency-management.md).
 
 Current pins (see [CHANGELOG.md](CHANGELOG.md) for the history):
 
@@ -60,8 +64,6 @@ Current pins (see [CHANGELOG.md](CHANGELOG.md) for the history):
 - `unicorn-binance-local-depth-cache >= 2.12.2`
 - `unicorn-binance-trailing-stop-loss >= 1.3.1`
 - `ubdcc >= 0.5.0`
-
-**Rule:** Never pin to a version that isn't released on PyPI yet — pip-resolver will silently fall through to the previous suite version. Bump constraints *after* upstream modules have been published.
 
 ---
 
@@ -80,7 +82,7 @@ CI runs the same across the full Python matrix.
 
 - **PyPI:** `.github/workflows/build_wheels.yml` builds the sdist + noarch wheel and publishes via trusted publisher on release.
 - **conda-forge:** the [unicorn-binance-suite-feedstock](https://github.com/conda-forge/unicorn-binance-suite-feedstock) picks up the new PyPI release automatically. `meta.yaml` in this repo is the local dev copy, not used by the feedstock.
-- **No in-repo conda build.** `build_conda.yml` was removed during the LUCIT cleanup round — conda-forge is the single conda source.
+- No in-repo conda build — why, and the `meta.yaml`/`environment.yml` boundary: [`context/packaging.md`](context/packaging.md).
 
 **Version bump** — `dev/set_version.py` (run by Oliver only). Version string lives in:
 1. `setup.py` — `version=`
@@ -108,13 +110,16 @@ A release cycle across the suite typically runs in dependency order:
 6. `ubdcc` (depends on UBLDC) — PyPI only (no conda-forge by design)
 7. **This repo** — bump pins to the new module versions, PyPI + feedstock bump
 
-Conda-forge channel indexing takes ~10–30 min per feedstock, so running downstream feedstock bumps too early will fail with unsatisfiable deps — wait for the upstream package to land in the channel.
+Why this exact order, the conda-forge indexing wait, and recurring release pitfalls: [`context/release-workflow.md`](context/release-workflow.md).
 
 ---
 
 ## Notes & Gotchas
 
 - Meta-package has no source code; any "bug" is really in one of the six modules.
-- The `meta.yaml` in this repo is for **local dev builds only**. Conda-forge uses its own feedstock recipe.
-- Don't add a `channels:` block to `meta.yaml` — it's not a valid key there; it belongs in `environment.yml` (`conda-forge` only, no `defaults`, no pip mixing).
-- `dev/sphinx/source/conf.py` has a legacy `'lucit': True` theme option — keep it (theme-specific).
+- Packaging/dependency gotchas (meta.yaml, channels, the Sphinx `'lucit': True` flag): see [`context/packaging.md`](context/packaging.md).
+
+<!-- keep-the-why:config -->
+- context: `context/`
+- init: complete
+<!-- /keep-the-why:config -->

--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Keep the Why](https://keepthewhy.com/assets/badge.svg)](https://keepthewhy.com)
 [![GitHub Release](https://img.shields.io/github/release/oliver-zehentleitner/unicorn-binance-suite.svg?label=github)](https://github.com/oliver-zehentleitner/unicorn-binance-suite/releases)
 [![GitHub Downloads](https://img.shields.io/github/downloads/oliver-zehentleitner/unicorn-binance-suite/total?color=blue)](https://github.com/oliver-zehentleitner/unicorn-binance-suite/releases)
 [![PyPi Release](https://img.shields.io/pypi/v/unicorn-binance-suite?color=blue)](https://pypi.org/project/unicorn-binance-suite/)

--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
-[![Keep the Why](https://keepthewhy.com/assets/badge.svg)](https://keepthewhy.com)
 [![GitHub Release](https://img.shields.io/github/release/oliver-zehentleitner/unicorn-binance-suite.svg?label=github)](https://github.com/oliver-zehentleitner/unicorn-binance-suite/releases)
 [![GitHub Downloads](https://img.shields.io/github/downloads/oliver-zehentleitner/unicorn-binance-suite/total?color=blue)](https://github.com/oliver-zehentleitner/unicorn-binance-suite/releases)
 [![PyPi Release](https://img.shields.io/pypi/v/unicorn-binance-suite?color=blue)](https://pypi.org/project/unicorn-binance-suite/)
@@ -14,6 +13,7 @@
 [![Read How To`s](https://img.shields.io/badge/read-%20howto-yellow)](https://blog.technopathy.club/series/unicorn-binance-suite)
 [![Telegram](https://img.shields.io/badge/community-telegram-41ab8c)](https://t.me/unicorndevs)
 [![Reddit](https://img.shields.io/badge/community-reddit-41ab8c)](https://www.reddit.com/r/UNICORNBinanceSuite)
+[![Keep the Why](https://keepthewhy.com/assets/badge.svg)](https://keepthewhy.com)
 
 [![UBS-Banner](https://raw.githubusercontent.com/oliver-zehentleitner/unicorn-binance-suite/master/images/logo/UBS-Banner-Readme.png)](https://blog.technopathy.club/page/unicorn-binance-suite)
 

--- a/context/dependency-management.md
+++ b/context/dependency-management.md
@@ -1,0 +1,23 @@
+# Dependency management
+
+## Deps are declared in 5 files, kept in sync manually
+
+**Status:** active
+**Inferred** (no alternative found in history — see below)
+
+`requirements.txt`, `setup.py`, `pyproject.toml`, `environment.yml`, and `meta.yaml` (local dev copy) all declare the suite's module dependencies independently. `setup.py` is the source of truth; the other four are updated by hand whenever it changes.
+
+**Reason (inferred):** the five files belong to four different packaging ecosystems (pip sdist, PEP 621/pyproject, conda env spec, conda recipe) that don't share a common dependency-declaration format this project generates from. No commit or discussion was found proposing a single generated source instead — this looks like the default state of a multi-ecosystem Python package rather than a considered-and-rejected alternative. Flagging as inferred rather than confirmed since no maintainer statement or history entry backs the "no alternative existed" reading specifically.
+
+## Never pin to a version that isn't released on PyPI yet
+
+**Status:** active
+**Confirmed** (maintainer)
+
+When bumping a suite-module constraint (e.g. `unicorn-binance-websocket-api >= 2.15.0`), the new floor must already be published on PyPI before the commit lands here.
+
+**Reason:** pip's resolver doesn't error on an unsatisfiable floor — it silently falls back to the newest version that *is* available, which is the previous one. The bump then looks like it landed but has no actual effect, and the mismatch isn't visible until something that depends on the new floor's behavior breaks downstream.
+
+**Rejected alternative:** bumping constraints as soon as the corresponding upstream PR merges (i.e. tracking source instead of tracking releases). Rejected for the reason above — a merged PR isn't a resolvable version yet.
+
+**How to apply:** bump suite pins only after the corresponding module's PyPI release is confirmed live, and after conda-forge indexing if the conda-side pin is also being bumped (see `release-workflow.md`).

--- a/context/history.md
+++ b/context/history.md
@@ -1,0 +1,16 @@
+# History
+
+## LUCIT branding/licensing removal (April 2026)
+
+**Status:** superseded — LUCIT is fully removed as of this cleanup round
+**Confirmed** (commits `83cc723`, `af0a4bf`, `c32edb2`, `097de55`, and others across April 2026)
+
+The suite previously had a "LUCIT" branding and licensing layer across all repos: a `lucit` conda channel (`meta.yaml`/`environment.yml`), a `lucit-licensing-python` host dependency, LUCIT-branded logos/badges, a `lucit.tech` security-contact form, and Matomo/Freshchat tracking snippets pointing at `lucit.*` domains in the Sphinx theme config.
+
+This was removed suite-wide: conda-forge is now the only conda channel, the licensing dependency is gone, logos and badges were replaced, and `SECURITY.md` now points to GitHub Security Advisories instead of the LUCIT contact form.
+
+**Reason:** LUCIT is no longer part of how this suite is distributed or supported — the packages are self-contained, licensed under plain MIT, and distributed solely through PyPI, conda-forge, and GitHub.
+
+**Leftover, deliberately kept:** the Sphinx theme's `'lucit': True` option in `conf.py` (see `packaging.md`) — it's a theme feature flag, not a brand reference, and removing it would need a theme-level change, not just a repo cleanup.
+
+**Revisit when:** the suite forks its own Sphinx theme (see suite-wide plan) — re-check whether the `'lucit'` flag still applies under the new theme.

--- a/context/index.md
+++ b/context/index.md
@@ -1,0 +1,6 @@
+# Context index
+
+- [release-workflow.md](release-workflow.md) — why releases across the suite follow a strict dependency order, and the recurring pitfalls that order exists to avoid
+- [dependency-management.md](dependency-management.md) — why deps are duplicated across 5 files instead of one source, and the pin-timing rule
+- [packaging.md](packaging.md) — conda/meta.yaml boundaries, why there's no in-repo conda build, the Sphinx theme flag
+- [history.md](history.md) — the 2026 LUCIT branding/licensing removal

--- a/context/packaging.md
+++ b/context/packaging.md
@@ -1,0 +1,32 @@
+# Packaging
+
+## No in-repo conda build
+
+**Status:** active
+**Confirmed** (commit 83cc723, 2026-04-18)
+
+`.github/workflows/build_conda.yml` was removed; conda-forge's own feedstock (`unicorn-binance-suite-feedstock`) is the only conda build path. `meta.yaml` in this repo is kept only as a local dev copy — it's not used by the feedstock and not built in CI.
+
+**Reason:** conda-forge builds and publishes the conda package on its own infrastructure once the feedstock recipe is updated; an in-repo conda build was redundant with that and added a build path the feedstock doesn't consume anyway.
+
+**Rejected alternative:** keeping the in-repo conda build as a pre-publish sanity check. Rejected as part of the same cleanup — the feedstock's own CI already validates the recipe.
+
+## `channels:` doesn't belong in `meta.yaml`
+
+**Status:** active
+**Confirmed** (commit 83cc723, 2026-04-18)
+
+`meta.yaml` no longer has a `channels:` block. It was removed because conda-build silently ignores `channels:`/`dependencies:` keys there — those are `environment.yml` keys, not valid `meta.yaml` recipe keys. Silently ignored, not erroring, is what let it sit there unnoticed for a while.
+
+**How to apply:** channel configuration (`conda-forge` only, no `defaults`, no pip mixing) belongs in `environment.yml`, never in `meta.yaml`.
+
+## Sphinx theme's `'lucit': True` flag
+
+**Status:** active
+**Inferred**
+
+`dev/sphinx/source/conf.py` sets `'lucit': True` in `html_context`, even though the LUCIT branding/licensing cleanup (see `history.md`) removed LUCIT elsewhere in the repo (badges, channel refs, contact URLs).
+
+**Reason (inferred):** this is a boolean feature flag consumed by the custom Sphinx theme (`python_docs_theme_lucit`) to switch on a layout/behavior mode, not a literal LUCIT brand reference — removing it would change how the theme renders, not just cosmetic wording. No commit was found explaining the flag's internal meaning inside the theme itself; kept as inferred since that would require reading the theme package's source, not just this repo's history.
+
+**Revisit when:** the suite forks or replaces `python_docs_theme_lucit` (see suite-wide plan to fork it into a UBS-specific theme variant) — at that point this flag's meaning should be re-checked against the new theme's option, not carried over blindly.

--- a/context/release-workflow.md
+++ b/context/release-workflow.md
@@ -1,0 +1,43 @@
+# Release workflow
+
+## Fixed release order across the suite
+
+**Status:** active
+**Confirmed** (maintainer)
+**Revisit when:** a new module is added to the suite, or a module's dependency graph changes
+
+Releases across the suite always go in this order:
+
+`unicorn-fy` → UBRA → UBWA → `UBLDC` + `UBTSL` (parallel) → `ubdcc` → `unicorn-binance-suite` (this repo, last)
+
+**Reason:** this is the dependency order (each module pins the ones before it), validated empirically during the April 2026 LUCIT-cleanup release round (see `history.md`) where releasing out of order produced unsatisfiable-dependency failures on conda-forge.
+
+**Rejected alternative:** releasing modules independently of this order (e.g. whenever a fix lands) was the implicit approach before that round. Rejected because a downstream module's conda-forge build fails outright if the upstream package hasn't finished indexing yet — not a soft warning, a hard build failure.
+
+## Wait for conda-forge indexing, not just for the merge
+
+**Status:** active
+**Confirmed** (maintainer)
+
+After a feedstock PR is merged, there's a ~15–30 minute gap before the package is actually indexed in the conda-forge channel. The next downstream module's feedstock bump must wait for indexing, not just for the merge to land.
+
+**Reason:** merging the feedstock PR triggers the build, but the resulting package isn't queryable by conda-forge's resolver until channel indexing finishes. Bumping a downstream feedstock's pin before that window closes fails with unsatisfiable dependencies, even though the upstream PR is already merged.
+
+## Bot-driven pin bumps vs. manual PRs
+
+**Status:** active
+**Confirmed** (maintainer)
+
+The conda-forge autotick bot opens pin-bump PRs in downstream feedstocks automatically once an upstream package updates. For simple pin bumps, these bot PRs are left for the maintainer to merge as needed — no manual PR is opened to chase them.
+
+**Reason:** manually duplicating what the bot already does is redundant. A manual PR is only opened when more than a pin bump is needed: a multi-layer cleanup round touching several modules at once, or an actual feature change in the downstream module itself.
+
+## Recurring pitfalls (not bugs, expected friction)
+
+- **CDN-cache race:** a feedstock PR's own CI goes green, but the subsequent main-branch build goes red on the same `meta.yaml` roughly a minute later. Not a real regression — the fix is a new build-number bump and retry. Most likely right after suite deps were just freshly published, before the CDN has caught up.
+- **Parallel pin-PR conflicts:** two bump PRs open at once both touch the same `CHANGELOG.md` `X.X.dev` block; merging one requires rebasing the other.
+- **Partial Azure builds:** if Azure (Windows/Mac) fails with transient git-fetch errors while Linux is green, the package can land incomplete in the channel. Fix: a new PR bumping `build.number` plus an explicit `@conda-forge-admin, please rerender` comment (the rerender request must be a comment, not text in the PR body — it isn't executed there).
+- **Python 3.14 migration silently reverts:** once a feedstock has been converted from `noarch: python` to a compiled build (Cython), a plain rerender can *delete* the existing `.ci_support/*python3.14*` files instead of regenerating them, because conda-smithy falls back to global pinning defaults without an active migration file. Fix: ensure `.ci_support/migrations/python314.yaml` exists in the feedstock (copy from conda-forge's `conda-forge-pinning-feedstock` migrations, or from `unicorn-binance-websocket-api-feedstock` which already has it), commit it, then rerender. Check for this file on every UBS feedstock bump — it's easy to lose 3.14 support silently on a routine rerender otherwise.
+- **Autotick bot opens a redundant version-bump PR in parallel** with a manual one — just close it (requires maintainer, the AIgent account has no close rights on those repos).
+
+**Evidence:** all of the above validated during the April 2026 (2026-04-18/19) suite-wide cleanup release round.


### PR DESCRIPTION
## Summary
- Adopts the Keep the Why convention: a `context/` directory documenting the reasoning behind release ordering, dependency-pin timing, and packaging decisions (previously stated as bare rules in AGENTS.md without the why)
- `AGENTS.md` trimmed: inline rationale replaced with pointers to `context/`
- `README.md`: Keep the Why badge added
- `.gitignore`: `AGENTS.local.md` (personal config, not committed)

## Test plan
- [ ] Read through `context/*.md` for accuracy against actual history
- [ ] Confirm AGENTS.md pointers resolve correctly