### PR TITLE
Add context/README.md (Keep the Why folder landing page)

### DIFF
--- a/context/README.md
+++ b/context/README.md
@@ -1,0 +1,10 @@
+<img src="https://keepthewhy.com/assets/logo.png" alt="Keep the Why" width="200">
+
+# Context
+
+Why this project is built the way it is — architecture decisions,
+rejected alternatives, workarounds, and reasoning the code alone
+can't show. Captured and kept current by the [Keep the
+Why](https://keepthewhy.com) agent skill.
+
+Not usage docs — see `docs/` for that. Start with `index.md`.


### PR DESCRIPTION
## Summary
- Adds `context/README.md` — GitHub renders this automatically when browsing the folder, so it's what someone sees landing in `context/` cold, without already knowing what Keep the Why is
- Follow-up to #65, which predated this convention in the skill's own setup flow