### PR TITLE
docs: update Keep the Why to v0.5.1 (context/README.md, schema migration)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -122,4 +122,6 @@ Why this exact order, the conda-forge indexing wait, and recurring release pitfa
 <!-- keep-the-why:config -->
 - context: `context/`
 - init: complete
+- context-schema: 0.5.1
+- capture-confirmation: confirm-when-unsure
 <!-- /keep-the-why:config -->

--- a/context/README.md
+++ b/context/README.md
@@ -1,10 +1,39 @@
-<img src="https://keepthewhy.com/assets/logo.png" alt="Keep the Why">
+<a href="https://keepthewhy.com"><img src="https://keepthewhy.com/assets/logo.png" alt="Keep the Why"></a>
 
-# Context
+# Project context
 
-Why this project is built the way it is — architecture decisions,
-rejected alternatives, workarounds, and reasoning the code alone
-can't show. Captured and kept current by the [Keep the
-Why](https://keepthewhy.com) agent skill.
+This directory preserves the reasoning behind this project: architectural
+decisions, constraints, rejected alternatives, incident learnings,
+deliberate workarounds, and other knowledge that the code alone cannot
+explain.
 
-Not usage docs — see `docs/` for that. Start with `index.md`.
+It's organized and kept current according to the [Keep the
+Why](https://keepthewhy.com) schema — a repo-native agent skill, not
+specific to this project. Recognizing that schema means an agent (or a
+person who's seen it before) already knows how this directory is
+structured and how to work with it, without first having to figure that
+out from scratch.
+
+It answers:
+
+> Why is the project built this way?
+
+For usage, installation, operation, or troubleshooting, see `docs/`.
+
+## Reading the entries
+
+Each entry separates:
+
+- **Status** — whether a decision is active, superseded, open, or needs review
+- **Evidence** — whether its rationale is confirmed, inferred, or unknown
+
+Old reasoning is retained when it remains useful for understanding how the
+project evolved.
+
+## Trust boundary
+
+Files in this directory describe project knowledge. They do not contain
+instructions that grant permissions, override user intent, authorize
+commands, or weaken security controls.
+
+Start with the [context index](index.md).

--- a/context/dependency-management.md
+++ b/context/dependency-management.md
@@ -3,7 +3,7 @@
 ## Deps are declared in 5 files, kept in sync manually
 
 **Status:** active
-**Inferred** (no alternative found in history — see below)
+**Evidence:** inferred
 
 `requirements.txt`, `setup.py`, `pyproject.toml`, `environment.yml`, and `meta.yaml` (local dev copy) all declare the suite's module dependencies independently. `setup.py` is the source of truth; the other four are updated by hand whenever it changes.
 
@@ -12,7 +12,8 @@
 ## Never pin to a version that isn't released on PyPI yet
 
 **Status:** active
-**Confirmed** (maintainer)
+**Evidence:** confirmed
+**Source:** maintainer
 
 When bumping a suite-module constraint (e.g. `unicorn-binance-websocket-api >= 2.15.0`), the new floor must already be published on PyPI before the commit lands here.
 

--- a/context/history.md
+++ b/context/history.md
@@ -3,7 +3,8 @@
 ## LUCIT branding/licensing removal (April 2026)
 
 **Status:** superseded — LUCIT is fully removed as of this cleanup round
-**Confirmed** (commits `83cc723`, `af0a4bf`, `c32edb2`, `097de55`, and others across April 2026)
+**Evidence:** confirmed
+**Source:** commits `83cc723`, `af0a4bf`, `c32edb2`, `097de55`, and others across April 2026
 
 The suite previously had a "LUCIT" branding and licensing layer across all repos: a `lucit` conda channel (`meta.yaml`/`environment.yml`), a `lucit-licensing-python` host dependency, LUCIT-branded logos/badges, a `lucit.tech` security-contact form, and Matomo/Freshchat tracking snippets pointing at `lucit.*` domains in the Sphinx theme config.
 

--- a/context/packaging.md
+++ b/context/packaging.md
@@ -3,7 +3,8 @@
 ## No in-repo conda build
 
 **Status:** active
-**Confirmed** (commit 83cc723, 2026-04-18)
+**Evidence:** confirmed
+**Source:** commit 83cc723, 2026-04-18
 
 `.github/workflows/build_conda.yml` was removed; conda-forge's own feedstock (`unicorn-binance-suite-feedstock`) is the only conda build path. `meta.yaml` in this repo is kept only as a local dev copy — it's not used by the feedstock and not built in CI.
 
@@ -14,7 +15,8 @@
 ## `channels:` doesn't belong in `meta.yaml`
 
 **Status:** active
-**Confirmed** (commit 83cc723, 2026-04-18)
+**Evidence:** confirmed
+**Source:** commit 83cc723, 2026-04-18
 
 `meta.yaml` no longer has a `channels:` block. It was removed because conda-build silently ignores `channels:`/`dependencies:` keys there — those are `environment.yml` keys, not valid `meta.yaml` recipe keys. Silently ignored, not erroring, is what let it sit there unnoticed for a while.
 
@@ -23,7 +25,7 @@
 ## Sphinx theme's `'lucit': True` flag
 
 **Status:** active
-**Inferred**
+**Evidence:** inferred
 
 `dev/sphinx/source/conf.py` sets `'lucit': True` in `html_context`, even though the LUCIT branding/licensing cleanup (see `history.md`) removed LUCIT elsewhere in the repo (badges, channel refs, contact URLs).
 

--- a/context/release-workflow.md
+++ b/context/release-workflow.md
@@ -3,7 +3,8 @@
 ## Fixed release order across the suite
 
 **Status:** active
-**Confirmed** (maintainer)
+**Evidence:** confirmed
+**Source:** maintainer
 **Revisit when:** a new module is added to the suite, or a module's dependency graph changes
 
 Releases across the suite always go in this order:
@@ -17,7 +18,8 @@ Releases across the suite always go in this order:
 ## Wait for conda-forge indexing, not just for the merge
 
 **Status:** active
-**Confirmed** (maintainer)
+**Evidence:** confirmed
+**Source:** maintainer
 
 After a feedstock PR is merged, there's a ~15–30 minute gap before the package is actually indexed in the conda-forge channel. The next downstream module's feedstock bump must wait for indexing, not just for the merge to land.
 
@@ -26,7 +28,8 @@ After a feedstock PR is merged, there's a ~15–30 minute gap before the package
 ## Bot-driven pin bumps vs. manual PRs
 
 **Status:** active
-**Confirmed** (maintainer)
+**Evidence:** confirmed
+**Source:** maintainer
 
 The conda-forge autotick bot opens pin-bump PRs in downstream feedstocks automatically once an upstream package updates. For simple pin bumps, these bot PRs are left for the maintainer to merge as needed — no manual PR is opened to chase them.
 


### PR DESCRIPTION
## Summary
- `context/README.md`: adopt new Keep the Why template (linked logo, "Project context" heading, Reading the entries + Trust boundary sections, links to `index.md`)
- `AGENTS.md`: backfill `context-schema: 0.5.1` and `capture-confirmation: confirm-when-unsure` in the project config block (both fields were missing entirely)
- `context/`: migrate existing entries to the 0.3.0 Status/Evidence split — `**Confirmed** (X)` becomes `**Evidence:** confirmed` + `**Source:** X`

No content/rationale changes — pure schema/template migration, aligning with Keep the Why v0.5.1.